### PR TITLE
Replace ntpclient with ntpdate

### DIFF
--- a/files/4-rinkhals/start.sh
+++ b/files/4-rinkhals/start.sh
@@ -66,7 +66,7 @@ quit() {
 }
 
 export TZ=UTC
-ntpd -q -g -c /tmp/ntp.conf -d > /dev/null # Try to sync local time before starting
+ntpdate -u pool.ntp.org > /dev/null 2>&1 > /dev/null # Try to sync local time before starting
 
 KOBRA_VERSION=`cat /useremain/dev/version`
 RINKHALS_ROOT=`dirname $(realpath $0)`


### PR DESCRIPTION
**Context:** The original script relies on `ntpclient` to synchronize time with the NTP server (`pool.ntp.org`). However, `ntpclient` is not available on the systems, causing errors and preventing the script from functioning correctly.

---

**Changes Made:**  
1. **Replaced `ntpclient` with `ntpd`:**  
  - Leveraging `ntpd` with the following options: 
    - `-q`: Performs a one-time synchronization and exits.
 
    - `-c /tmp/ntp.conf`: Specifies a temporary configuration file.
 
    - `-d`: Enables debug mode for troubleshooting synchronization issues.
 
2. **Added a temporary NTP configuration file:**  
  - A minimal file (`/tmp/ntp.conf`) is created with the following content:
 
3. **Redirected output to `/dev/null`:** 
  - Suppresses unnecessary output to keep the script clean.
---

**Impact:**  
- No regressions expected, especially since `ntpclient` was likely non-functional.