### PR TITLE
Switch from ntpclient to ntpdate

### DIFF
--- a/files/4-rinkhals/start.sh
+++ b/files/4-rinkhals/start.sh
@@ -66,7 +66,7 @@ quit() {
 }
 
 export TZ=UTC
-ntpdate -u pool.ntp.org > /dev/null 2>&1 > /dev/null # Try to sync local time before starting
+ntpdate -u pool.ntp.org > /dev/null # Try to sync local time before starting
 
 KOBRA_VERSION=`cat /useremain/dev/version`
 RINKHALS_ROOT=`dirname $(realpath $0)`


### PR DESCRIPTION
ntpclient was unavailable on the target system, so it has been replaced with ntpdate, which is readily available and serves the same purpose for one-shot time synchronization. The change simplifies the workflow and ensures compatibility.

