### PR TITLE
Added note about the type of mainboard that MUST be present in the Kobra 2 Pro since there are different versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 # Rinkhals
 
-Rinkhals is a custom firmware for the Anycubic Kobra series of 3D printers. The goal of this project is to create a simple and safe overlay for the Kobra firmware, adding some usefule features.
+Rinkhals is a custom firmware for certain Anycubic Kobra 3D printers that run KobraOS. The goal of this project is to create a simple and safe overlay for the KobraOS firmware, adding some usefule features.
 This firmware will likely not support all use cases, like running vanilla Klipper or your specific feature / plugin.
 
 For now the following printers and firmwares are supported:
 - Kobra 3 (+ combo) with firmware 2.3.5.3
-- Kobra 2 Pro and firmware 3.1.2.3 (must have mainboard type "[Trigorilla Spe **B** v1.0.x](https://1coderookie.github.io/Kobra2ProInsights/hardware/mainboard/#trigorilla_spe_b_v10x-stock-new-revision)"!)
+- Kobra 2 Pro and firmware 3.1.2.3 (*must* have mainboard type "[Trigorilla Spe **B** v1.0.x](https://1coderookie.github.io/Kobra2ProInsights/hardware/mainboard/#trigorilla_spe_b_v10x-stock-new-revision)")
 
 Here are some of the features I added:
 - Mainsail, Fluidd and Moonraker (using nginx)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This firmware will likely not support all use cases, like running vanilla Klippe
 
 For now the following printers and firmwares are supported:
 - Kobra 3 (+ combo) with firmware 2.3.5.3
-- Kobra 2 Pro with firmware 3.1.2.3
+- Kobra 2 Pro and firmware 3.1.2.3 (must have mainboard type "[Trigorilla Spe **B** v1.0.x](https://1coderookie.github.io/Kobra2ProInsights/hardware/mainboard/#trigorilla_spe_b_v10x-stock-new-revision)"!)
 
 Here are some of the features I added:
 - Mainsail, Fluidd and Moonraker (using nginx)
@@ -23,7 +23,7 @@ This project is named after rinkhals. They are a sub-species of Cobras ... Kobra
 
 The stock firmwares are available on a separate branch: https://github.com/jbatonnet/Rinkhals/tree/stock-firmwares
 
-If you are interested in development anf/or testing, join me on Discord: https://discord.gg/3mrANjpNJC
+If you are interested in development and/or testing, join me on Discord: https://discord.gg/3mrANjpNJC
 
 <p align="center">
     <img width="48" src="https://github.com/jbatonnet/Rinkhals/blob/master/icon.png?raw=true" />


### PR DESCRIPTION
Hi Julien,
@moosbewohner reached out to me last week and informed me about your KobraOS mod. I'm the author of several infosites about various Kobra models, and since I didn't had your mod listed yet, he brought my attention to it.  

Now there's a really important thing which has to be mentioned (imho ;) ), because imho Rinkhals only works with a very specific version of the Trigorilla boards that Anycubic used in their various models, and especially because we seem to have different versions in the Kobra 2 Pro now, I think you should make that clear.  
If you don't mind, I'll try to explain the differences:  
Afaik, you initially modded the KobraOS of a Kobra 3. The Kobra 3 uses a "Trigorilla SPE B v1.1.x" (1.1.3 afaik), which uses a HC32F460 - the "SPE B" is the important thing here.  
Previous mobos were e.g. the Trigorilla PRO B v1.0.2, which is being used in the Kobra 2 - that one also uses a HC32F460, even a touchscreen, but the stock firmware is Marlin and not KobraOS, there's no WiFi and it can be flashed with a native Klipper.  
The only other Kobras that run KobraOS are the Kobra 2 Pro/Plus/Max, which originally were shipped with the Trigorilla "SPE A v1.0.0" - but that one has a different CPU. See here if you're interested: https://1coderookie.github.io/Kobra2ProInsights/hardware/mainboard/  
AC designed that mobo when they came up with their first iteration of KobraOS back then. They shipped thousands of printers with that mobo, and spare mainboards that are being shipped until today are those types as well. 
Now it seems that AC shipped at least a few units of the K2Pro with a new mobo, the Trigorilla SPE B v1.0.x (1.0.4 and 1.0.5 according to @moosbewohner) - which seems to be quite similar to the SPE B v1.1.x that's being used in the K3, and which seems to be the reason that your Rinkhals also works on @moosbewohner K2Pro, because he has that kind of mainboard.  

In other words, for the majority of the Kobra 2 Pro/Plus/Max users who have the SPE **A** version, I won't expect Rinkhals to  work, at least not without any modification. But I'm not a programmer, that's just what I assume due to the different architecture - not sure if one could do any harm in trying to flash it, or if one could get it to run by just using an according printer.cfg, but I wanted to let you know that there are different mobo versions out there, so that you might take the PR with the added note and the link. If you don't, no offense taken tho.. ;)
  
Anyway, I really like your solution and I mentioned it and linked to it at the according K2Pro/Plus/Max infosites.

Greetings