### PR TITLE
Fix some docs issues

### DIFF
--- a/docs/docs/Rinkhals/contribute-to-development.md
+++ b/docs/docs/Rinkhals/contribute-to-development.md
@@ -5,7 +5,7 @@ weight: 1
 
 Here are some aggregated answer I gave on Discord. If you want to now more, join the server and ask me!
 
-Also, have a look at the other pages, such as [File Structure - Kobra Startup Sequence](../Reverse engineering/file-structure.md#kobra-startup-sequence)
+Also, have a look at the other pages, such as [File Structure - Kobra Startup Sequence](../firmware/file-structure.md#kobra-startup-sequence)
 
 
 ## Questions and Answers

--- a/docs/docs/Rinkhals/index.md
+++ b/docs/docs/Rinkhals/index.md
@@ -70,8 +70,9 @@ Rinkhals is using [vanilla Moonraker](https://github.com/Arksine/moonraker) plus
 When using GoKlipper and LAN mode, this component will intercept Print calls from Mainsail, Fluid, Orca and more and replace it with a proprietary Anycubic call. This call allows a few settings to be changed, such as Bed leveling on print start, flow calibration and resonance testing.
 By default, those settings are all disabled for every print. This behavior can be changed using [app configuration](apps/configuration.md).
 
-> [!WARNING]
-> This app consumes a lot of memory. Be careful while using multiple frontends (Mainsail, Fluidd, ...) at the same time.
+!!! warning
+
+    This app consumes a lot of memory. Be careful while using multiple frontends (Mainsail, Fluidd, ...) at the same time.
 
 | 40-moonraker | |
 |-|-|
@@ -90,13 +91,15 @@ It's a SPA (Single Page Application) served using [Lighttpd](https://www.lighttp
 
 Lighttpd is also configured to expose up to 4 cameras proxying to mjpg-streamer. Cameras are accessible using /webcam or /webcam0 for the first one, then /webcam1, /webcam2 and /webcam3 for the other.
 
-> [!NOTE]
-> Port 80 is dynamically allocated depending on the order of app startup.<br />
-> By default during their startup, Mainsail and Fluidd will try to use port 80. This is made to ensure that you can expose multiple frontends while choosing which one is using port 80.
+!!! note
 
-> [!TIP]
-> It is possible to expose another interface on port 80.<br />
-> Make sure that your custom app open and listens to port 80 before Mainsail and/or Fluidd by using a name prefix with a number below 25.
+    Port 80 is dynamically allocated depending on the order of app startup.
+    By default during their startup, Mainsail and Fluidd will try to use port 80. This is made to ensure that you can expose multiple frontends while choosing which one is using port 80.
+
+!!! tip
+
+    It is possible to expose another interface on port 80.
+    Make sure that your custom app open and listens to port 80 before Mainsail and/or Fluidd by using a name prefix with a number below 25.
 
 | 25-mainsail | |
 |-|-|

--- a/docs/docs/Rinkhals/installation-and-firmware-updates.md
+++ b/docs/docs/Rinkhals/installation-and-firmware-updates.md
@@ -2,7 +2,7 @@
 title: Installation and firmware updates
 ---
 
-Check this page to better understand what is Rinkhals and how it works: [How Does Rinkhals work?](how-does-Rinkhals-work.md)
+Check this page to better understand what is Rinkhals and how it works: [How Does Rinkhals work?](installation-and-firmware-updates.md)
 
 ## Any firmware installation + SWU tools
 On the Kobra series of 3D printer, it's possible to sideload .swu files to install or execute things. For example, official updates are provided as .swu files, similar to Rinkhals and other firmwares.

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -9,7 +9,7 @@ GoKlipper (1) is not starting properly, it's most likely due to a printer config
 
 1. GoKlipper is Anycubic's reimplementation of Klipper in Go
 
-Please check the information in [I got 11407 or my printer doesn't boot anymore](printer-configuration.md#i-got-11407-or-my-printer-doesnt-boot-anymore)
+Please check the information in [I got 11407 or my printer doesn't boot anymore](Rinkhals/printer-configuration.md#i-got-11407-or-my-printer-doesnt-boot-anymore)
 
 
 ## How can I print multicolor / with the ACE from Orca Slicer?

--- a/docs/docs/firmware/index.md
+++ b/docs/docs/firmware/index.md
@@ -1,0 +1,6 @@
+---
+title: Home
+weight: -1
+---
+
+TODO

--- a/docs/docs/guides/index.md
+++ b/docs/docs/guides/index.md
@@ -1,0 +1,6 @@
+---
+title: Home
+weight: -1
+---
+
+TODO

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -14,6 +14,7 @@ The main project is located on GitHub: https://github.com/jbatonnet/Rinkhals
 This documentation covers what we know about those printers, what we know about Anycubic software, Rinkhals and some high levels guides to achieve specific things.
 
 In this documentation, the following printers will be refered to with their model code used everywhere in Rinkhals:
+
 - K2P: Anycubic Kobra 2 Pro
 - K3: Anycubic Kobra 3 (+ combo)
 - K3M: Anycubic Kobra 3 Max (+ combo)
@@ -25,10 +26,10 @@ In this documentation, the following printers will be refered to with their mode
 
 ## Documentation structure
 
-- [Rinkhals](rinkhals/): Documentation about Rinkhals, its features and internals
+- [Rinkhals](Rinkhals/): Documentation about Rinkhals, its features and internals
 - [Guides](guides/): High level guides for Simplyprint, Spoolman, ...
 - [Printers](printers/): Generic and specific documentation about the Anycubic Kobra series of 3D printer
-- [Firmware](kobra-firmware/): Reverse engineering and documentation about the firmware for those printers
+- [Firmware](firmware/): Reverse engineering and documentation about the firmware for those printers
 
 ## FAQ
 

--- a/docs/docs/printers/index.md
+++ b/docs/docs/printers/index.md
@@ -7,6 +7,7 @@ title: Kobra printers
 ## Printers
 
 Below you'll find documentation about specific printers:
+
 - [Anycubic Kobra 2 Pro](kobra-2-pro.md)
 - [Anycubic Kobra 3](kobra-3.md)
 - [Anycubic Kobra 3 V2](kobra-3-v2.md)


### PR DESCRIPTION
Fixes some issues with docs formatting and links

- Fixed a bunch of links that were broken when docs were reorganized
- Added missing `index.md` in new sections (namely `firmware` and `guides`, this is required if you want to link to that section without linking to a specific guide, such as what is done in the root `index.md` file)
- Fixed admonitions being formatted incorrectly for `mkdocs-material` (reference this for docs on how to use admonitions [https://squidfunk.github.io/mkdocs-material/reference/admonitions/](https://squidfunk.github.io/mkdocs-material/reference/admonitions/))