### PR TITLE
move TMPDIR to local disk

### DIFF
--- a/files/3-rinkhals/tools.sh
+++ b/files/3-rinkhals/tools.sh
@@ -1,3 +1,5 @@
+export TMPDIR=/useremain/tmp
+if [ ! -d ${TMPDIR} ] ; then mkdir ${TMPDIR} ; chmod a+rwx ${TMPDIR} ; fi
 export RINKHALS_ROOT=$(realpath /useremain/rinkhals/.current)
 export RINKHALS_VERSION=$(cat $RINKHALS_ROOT/.version)
 export RINKHALS_HOME=/useremain/home/rinkhals


### PR DESCRIPTION
TMPDIR by default is /tmp
/tmp is part of the tempfs which is a ramdisk. uploads via fluid/mainsail large tan 80M fail. This solves this issue