### PR TITLE
Fix progress bar display and position.

### DIFF
--- a/files/update.sh
+++ b/files/update.sh
@@ -23,39 +23,40 @@ log() {
 }
 
 progress() {
+    STATUS=${1}
     case "${KOBRA_MODEL_CODE}" in
         KS1)
-            PBX=16
-            PBY=16
-            PBH=32
-            PBW=iw-32
-            PCX=20
-            PCY=20
-            PCH=24
-            PCW=iw-40
+            PBX="16"
+            PBY="16"
+            PBH="32"
+            PBW="(iw-32)"
+            PCX="20"
+            PCY="20"
+            PCH="24"
+            PCW="(iw-40)"
             ;;
         K3M)
-            PBX=iw-48
-            PBY=32
-            PBW=32
-            PBH=ih-64
-            PCX=iw-44
-            PCY=36
-            PCW=24
-            PCH=ih-72
+            PBX="(iw-48)"
+            PBY="16"
+            PBW="32"
+            PBH="(ih-32)"
+            PCX="(iw-44)"
+            PCY="20"
+            PCW="24"
+            PCH="(ih-40)"
             ;;
         *)
-            PBX=16
-            PBY=16
-            PBW=32
-            PBH=ih-32
-            PCX=20
-            PCY=20
-            PCW=24
-            PCH=ih-40
+            PBX="16"
+            PBY="16"
+            PBW="32"
+            PBH="(ih-32)"
+            PCX="20"
+            PCY="20"
+            PCW="24"
+            PCH="(ih-40)"
         ;;
     esac
-    case "${1}" in
+    case "${STATUS}" in
         success)
             STAT_COLOR=green
             ;;
@@ -64,31 +65,20 @@ progress() {
             ;;
         *)
             STAT_COLOR=white
+            if [ "${STATUS}" = "0" ]; then
+              STATUS="0.005"
+            fi
             case "${KOBRA_MODEL_CODE}" in
                 KS1)
-                    if [ "${STATUS}" = "0" ]; then
-                        PCX="${PCX}+${PCW}-1"
-                        PCW=1
-                    else
-                        PCX="(${PCX})+((${PCW})-(${PCW})*${STATUS})"
-                        PCW="(${PCW})*${STATUS}"
-                    fi
+                    PCX="(${PCX})+((${PCW})-(${PCW})*${STATUS})"
+                    PCW="(${PCW})*${STATUS}"
                     ;;
                 K3M)
-                    if [ "${STATUS}" = "0" ]; then
-                        PCY="(${PCY})+(${PCH})-1"
-                        PCH=1
-                    else
-                        PCY="(${PCY})+((${PCH})-(${PCH})*${STATUS})"
-                        PCH="(${PCH})*${STATUS}"
-                    fi
+                    PCY="(${PCY})+((${PCH})-(${PCH})*${STATUS})"
+                    PCH="(${PCH})*${STATUS}"
                     ;;
                 *)
-                    if [ "${STATUS}" = "0" ]; then
-                        PCH="1"
-                    else
-                        PCH="(${PCH})*${STATUS}"
-                    fi
+                    PCH="(${PCH})*${STATUS}"
                     ;;
             esac
             ;;


### PR DESCRIPTION
Fixes a few things.
1) STATUS was not being set properly from $1, causing the progress bar to not display in some parts of the function.
2) ffmpeg does not like multiplying and/or adding 0? So if 0 is passed to progress I change it to 0.05 which shows a small white sliver of progress when first starting and also allowed simplification of some of the following logic as we no longer need to manually set the bar width to 1px.
3) Adjusted size of the progress bar for K3M as it was shorter than K3.
4) Wrapped values in quotes and parens to ensure ffmpeg could interpret it properly.