### PR TITLE
Further improve ffmpeg filters.

### DIFF
--- a/files/3-rinkhals/opt/rinkhals/ui/rinkhals-ui.sh
+++ b/files/3-rinkhals/opt/rinkhals/ui/rinkhals-ui.sh
@@ -21,7 +21,7 @@ echo
 # Add icon overlay while Python is loading
 if [ "$KOBRA_MODEL_CODE" = "KS1" ]; then
     SCALE="0.75"
-    TRANSPOSE="transpose=1,transpose=1"
+    TRANSPOSE="vflip,hflip"
     FILTER="[0:v] drawbox=x=0:y=0:w=iw:h=ih:t=fill:c=black"
 elif [ "$KOBRA_MODEL_CODE" = "K3M" ]; then
     SCALE="0.5"

--- a/files/3-rinkhals/start.sh
+++ b/files/3-rinkhals/start.sh
@@ -81,7 +81,7 @@ kill_by_name gklib 15 # SIGTERM to be softer ok gklib
 
 if [ -f /ac_lib/lib/third_bin/ffmpeg ]; then
     if [ "$KOBRA_MODEL_CODE" = "KS1" ]; then
-        TRANSPOSE="transpose=1,transpose=1"
+        TRANSPOSE="vflip,hflip"
         SCALE="0.75"
     elif [ "$KOBRA_MODEL_CODE" = "K3M" ]; then
         TRANSPOSE="transpose=2"


### PR DESCRIPTION
Completely out of curiosity I did some testing with ffmpeg and a 10second video clip on my local machine to see which filters would be fastest. Here was my test command:

ffmpeg -i input.mp4 -t 00:00:10 -vf 'bench@pre=start,${filters},bench@post=stop' -f null -

Results:

Control/no rotation: 24-25x video speed

For 90 rotation:
rotate=90 or 270: 4-5x video speed
transpose=0 or 1: 18-19x video speed
vflip,hflip: N/A

For 180 rotation
rotate=180: 4-5x video speed
transpose=1,transpose=1: 17-18x video speed
hflip,vflip: 20-21x video speed

So, for the KS1 at least, we can improve the 180 rotation even further by changing it to vflip,hflip. This PR does that.
Important? No, but since I had the results I figured I would make the change.