### PR TITLE
WIPE_ENTER before WIPE_NOZZLE

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
@@ -473,9 +473,9 @@ class Kobra:
                             f'M140 S{bed_temp}', # Set bed to 60
                             f'M109 S{extru_temp}', # Wait hotend to 170
                             f'M190 S{bed_temp}', # Wait bed to 60
-                            'WIPE_ENTER',
-                            'WIPE_NOZZLE',
-                            'WIPE_EXIT',
+                            'WIPE_ENTER', # Move to wiping position
+                            'WIPE_NOZZLE', # Wipe nozzle
+                            'WIPE_EXIT', # Exit wiping position
                             f'M109 S{extru_end_temp}', # Wait hotend to 140
                             'BED_MESH_CALIBRATE',
                             'TURN_OFF_HEATERS',


### PR DESCRIPTION
Ensures that the printhead actually moves to the wiping position.

Right now the wiping takes place midair, with WIPE_ENTER it actually moves to the correct position to wipe the nozzle. 