### PR TITLE
fix duplicate keys in cfg when whitespace mismatched

### DIFF
--- a/files/3-rinkhals/opt/rinkhals/scripts/process-cfg.py
+++ b/files/3-rinkhals/opt/rinkhals/scripts/process-cfg.py
@@ -69,14 +69,18 @@ def main():
         for key, value in sectionContent:
             #if key.lstrip().startswith('#'):
             #    continue
+            
+            # normalize key by stripping leading/trailing whitespace to avoid
+            # duplicates caused by spacing before the colon
+            key = key.strip()
 
             if key.startswith('!'):
-                key = key[1:]
+                key = key[1:].strip()
                 if key in resolvedSections[sectionName]:
                     resolvedSections[sectionName].pop(key)
                 continue
 
-            resolvedSections[sectionName][key.lstrip()] = value
+            resolvedSections[sectionName][key] = value
 
     # Write resolved sections to destination file
     print('# This file is generated automatically on every Rinkhals startup')


### PR DESCRIPTION
### trim key whitespace to prevent duplicate entries

**What / Why**  
`process-cfg.py` treated  
`max_velocity:` and `max_velocity :` as two different keys, so mixed-spacing configs produced duplicate lines in `printer.generated.cfg`.

**Fix**  
Strip leading/trailing blanks from every key (and from `!key` removals) before inserting into `resolvedSections`.

**Demo**

Input files  
```ini
# printer.rinkhals.cfg
[printer]
max_velocity: 200
```

```ini
# printer.custom.cfg
[printer]
max_velocity : 250
```

Generated result
before:
```ini
[printer]
max_velocity: 200
max_velocity : 250
```
after:
```ini
[printer]
max_velocity: 250
```

No other behaviour changes; section overrides and `!key` deletions still work as before.