### PR TITLE
Feature: ACE Metadata with Hardware Detection

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
@@ -167,6 +167,17 @@ class Kobra:
             return False
         return self.get_remote_mode() == 'lan'
 
+    def is_ace_available(self):
+        """Check if ACE (Anycubic Color Engine) hardware is connected."""
+        # ACE availability is indicated by the presence of ams_config.cfg
+        ace_config_path = '/userdata/app/gk/config/ams_config.cfg'
+        is_available = os.path.isfile(ace_config_path)
+        if is_available:
+            logging.debug('[ACE] ACE hardware detected')
+        else:
+            logging.debug('[ACE] No ACE hardware found')
+        return is_available
+
     def mqtt_print_file(self, file):
         logging.info(f'Trying to print {file} using MQTT...')
 
@@ -190,6 +201,17 @@ class Kobra:
                 }
             }
         }
+
+        # Add ACE metadata for multi-material support
+        # Only add if ACE hardware is actually connected
+        if self.KOBRA_MODEL_CODE == 'K3' and self.is_ace_available():
+            # Add minimal ams_settings with standard mapping
+            # This enables multi-material prints without requiring MMU GUI features
+            print_data["data"]["ams_settings"] = {
+                "use_ams": True,
+                "ams_box_mapping": ["0", "1", "2", "3"]
+            }
+            logging.info('[ACE Metadata] Added ams_settings with standard mapping')
 
         payload = json.dumps(print_data)
 


### PR DESCRIPTION
# ACE Metadata - Enable Multi-Material Printing

**Feature:** Minimal ACE Metadata for Multi-Material Support  
**Type:** Feature Addition  
**Depends on:** PR #1 (ACE Flush Control)  
**Related:** #139 (MMU GUI by @Hatles)

---

## 📋 Summary

This PR adds **minimal ACE metadata** to MQTT print payloads, enabling multi-material printing with the ACE system. This is a small (~10 lines) but essential addition that makes multi-material prints work "out of the box" without requiring manual configuration.

---

## 🎯 Problem

Without `ams_settings` in the MQTT payload, multi-material G-Code files cannot be printed via Moonraker → MQTT → GoKlipper. The ACE system needs to know which tool (T0-T3) maps to which physical gate (0-3).

**Current Behavior (without this PR):**
- Multi-material G-Code sent to printer
- GoKlipper receives file but has no tool mapping
- Print fails or uses incorrect filaments

---

## ✅ Solution

Add minimal `ams_settings` with standard tool mapping to MQTT payload, with automatic ACE hardware detection:

```json
{
  "data": {
    "filename": "multicolor.gcode",
    "ams_settings": {
      "use_ams": true,
      "ams_box_mapping": ["0", "1", "2", "3"]
    },
    "task_settings": { ... }
  }
}
```

**ACE Hardware Detection:**
- Checks for `/userdata/app/gk/config/ams_config.cfg` presence
- Only adds `ams_settings` when ACE is actually connected
- Prevents errors on printers without ACE hardware

**Mapping:**
- T0 → Gate 0 (physical slot 1)
- T1 → Gate 1 (physical slot 2)
- T2 → Gate 2 (physical slot 3)
- T3 → Gate 3 (physical slot 4)

---

## 🔧 Implementation

### Changes

**files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py**
- Added `is_ace_available()` method for hardware detection
- Modified `mqtt_print_file()` method
- Added ~20 lines for ACE detection and `ams_settings` injection
- Kobra 3 only (model code check)

### Code

```python
def is_ace_available(self):
    """Check if ACE (Anycubic Color Engine) hardware is connected."""
    ace_config_path = '/userdata/app/gk/config/ams_config.cfg'
    is_available = os.path.isfile(ace_config_path)
    if is_available:
        logging.debug('[ACE] ACE hardware detected')
    else:
        logging.debug('[ACE] No ACE hardware found')
    return is_available

# Add ACE metadata for multi-material support
# Only add if ACE hardware is actually connected
if self.KOBRA_MODEL_CODE == 'K3' and self.is_ace_available():
    # Add minimal ams_settings with standard mapping
    # This enables multi-material prints without requiring MMU GUI features
    print_data["data"]["ams_settings"] = {
        "use_ams": True,
        "ams_box_mapping": ["0", "1", "2", "3"]
    }
    logging.info('[ACE Metadata] Added ams_settings with standard mapping')
```

---

## 📊 Benefits

### Functionality

✅ **Multi-material prints work immediately**
✅ **No manual ams_settings configuration**
✅ **Automatic ACE hardware detection**
✅ **No errors on printers without ACE**
✅ **Standard 1:1 tool mapping**
✅ **Compatible with ACE Flush Control (PR #1)**
✅ **Foundation for advanced MMU features**

### Integration

This PR works **independently** but is **complementary** to:
- **PR #1 (ACE Flush Control):** Optimizes hardware purge
- **PR #139 (MMU GUI by @Hatles):** Adds advanced tool mapping and GUI

**Together:** Complete multi-material workflow with optimization

---

## 🧪 Testing

### Test Scenario

1. Slice multi-material object in OrcaSlicer (2+ colors)
2. Upload G-Code to Moonraker
3. Start print via Mainsail/Fluidd
4. Verify MQTT payload contains `ams_settings`
5. Verify print uses correct filaments per tool

### Expected MQTT Payload

```json
{
  "type": "print",
  "data": {
    "filename": "test.gcode",
    "ams_settings": {
      "use_ams": true,
      "ams_box_mapping": ["0", "1", "2", "3"]
    },
    "task_settings": {
      "auto_leveling": 1,
      "vibration_compensation": 1,
      "flow_calibration": 1
    }
  }
}
```

---

## 📁 Files Changed

### Modified Files

**files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py**
- Added `ams_settings` to MQTT payload
- Model-specific (Kobra 3 only)
- Standard tool mapping

**Changes:**
- +22 lines added (ACE detection + ams_settings injection)
- No breaking changes
- Backwards compatible
- Safe for printers without ACE hardware

---

## ⚠️ Important Notes

### Scope

This is a **minimal implementation** focusing on:
- ✅ Basic multi-material functionality
- ✅ Standard 1:1 tool mapping
- ✅ Kobra 3 support

**NOT included** (those are in PR #139):
- ❌ Dynamic tool mapping (custom T→G assignments)
- ❌ MMU GUI panel in Fluidd/Mainsail
- ❌ Material detection and `ace_list` generation
- ❌ Spoolman integration

### Relationship to PR #139

This PR provides **basic functionality** that can be **extended** by PR #139:

```
PR #1: ACE Flush Control → Optimizes purge
PR #2: ACE Metadata      → Enables multi-material (THIS PR)
PR #139: MMU GUI         → Adds advanced features
```

All three can work together or independently.

---

## 🔄 Backwards Compatibility

- ✅ No breaking changes
- ✅ Only adds data to MQTT payload
- ✅ Kobra 3 specific (no impact on other models)
- ✅ Standard mapping matches default behavior

---

## 🚀 Future Extensions

This minimal implementation can be extended with:
- **ace_list generation** from G-Code metadata
- **Dynamic tool mapping** from slicer
- **Material detection** from filament hub
- **Spoolman integration** for spool tracking

These extensions are being developed in PR #139 by @Hatles.

---

## 📚 Documentation

No additional documentation needed. This is a backend change that "just works" for multi-material prints.

For users:
- No configuration required
- Standard mapping matches OrcaSlicer defaults
- Works with ACE Flush Control macros

---

## 📝 Notes

- **Base:** This PR is based on PR #1 (ACE Flush Control)
- **Merge Order:** Should be merged after PR #1
- **Testing:** Deployed and tested on Anycubic Kobra 3
- **Compatibility:** Works alongside PR #139 without conflicts

---

## 🤝 Contributing

**Related PRs:**
- PR #1 - ACE Flush Control (base)
- #139 - MMU ACE Integration (advanced features by @Hatles)

**Related Issues:**
- #273 - flush_multiplier discussion