### PR TITLE
fix(kobra): Add LED control support for Kobra 3 Max and Kobra 3 V2

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
@@ -88,8 +88,8 @@ class Kobra:
 
     async def component_init(self):
 
-        if self.KOBRA_MODEL_CODE == 'K3':
-            # Add camera and head lights power devices
+        if self.KOBRA_MODEL_CODE in ('K3', 'K3M', 'K3V2'):
+            # Add camera and head lights power devices for K3, K3 Max and K3 V2
             config = self.server.config.read_supplemental_dict({
                 'power camera_light': {
                     'type': 'shell',


### PR DESCRIPTION
## Summary

- Adds K3M and K3V2 to the LED device initialization condition in `kobra.py`
- Enables `camera_light` and `head_light` power devices in Mainsail/Fluidd for Kobra 3 Max and Kobra 3 V2 users

## Details

The Kobra 3 Max and Kobra 3 V2 share the same LED control hardware and IPC commands as the K3:
- **camera_light**: via `v4l2-ctl` gain control or `Led/SetCameraLed` IPC command
- **head_light**: via `led/set_led` IPC command

The fix changes the condition from `K3` to `K3, K3M, K3V2`.

## Testing Limitations

**This change could NOT be tested on actual K3M or K3V2 hardware** - we don't have access to these printers.

The assumption is that K3M and K3V2 use the same LED control IPC commands as K3, based on:
- Similar hardware platform
- Same IPC socket architecture (`/tmp/unix_uds1`)
- Documentation showing identical LED commands across K3 variants

**Needs testing by a K3M or K3V2 user before merging.**

## Test plan

- [x] Verified LED control still works on K3 (regression test)
- [ ] Needs testing on actual K3M hardware
- [ ] Needs testing on actual K3V2 hardware by @pacocatech or another K3V2 user

Fixes #326