### PR TITLE
fix(docu): markdown link

### DIFF
--- a/docs/docs/firmware/vanilla-klipper.md
+++ b/docs/docs/firmware/vanilla-klipper.md
@@ -4,9 +4,7 @@ title: Vanilla Klipper
 
 Working on the K2P:
 
-- App and config are provided here: [https://github.com/jbatonnet/Rinkhals.apps/blob/master/apps/vanilla-klipper](https://github.com/jbatonnet/Rinkhals.apps/blob/master/apps/vanilla-klipper
-
-)
+- App and config are provided here: [https://github.com/jbatonnet/Rinkhals.apps/blob/master/apps/vanilla-klipper](https://github.com/jbatonnet/Rinkhals.apps/blob/master/apps/vanilla-klipper)
 
 For K3 and KS1, some drivers are missing. Here is the patch I applied to the default config to make Klipper start: [https://github.com/jbatonnet/Rinkhals.apps/blob/047a7736451d4e8da64910ad9adc34384710ac73/apps/vanilla-klipper/printer.klipper_K3.cfg.patch](https://github.com/jbatonnet/Rinkhals.apps/blob/047a7736451d4e8da64910ad9adc34384710ac73/apps/vanilla-klipper/printer.klipper_K3.cfg.patch)
 


### PR DESCRIPTION
Fix markdown linkt in vanilla-klipper documentation