### PR TITLE
M555 appears broken on newer Anycubic firmware; recommend SET_SPOOL

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/kobra.py
@@ -490,15 +490,16 @@ class Kobra:
         from .spoolman import SpoolManager
 
         def wrap_set_active_spool(original_set_active_spool):
-            def set_active_spool(me, spool_id = None, SPOOL_ID = None):
-                if spool_id is None:
-                    logging.info('[Kobra] Injected SPOOL_ID')
-                    spool_id = int(SPOOL_ID)
-                return original_set_active_spool(me, spool_id)
+            def set_active_spool(me, spool_id = None, SPOOL_ID = None, **kwargs):
+                if spool_id is not None:
+                    return original_set_active_spool(me, spool_id)
+                if SPOOL_ID is not None and str(SPOOL_ID).strip() != "":
+                    logging.info('[Kobra] Using fallback SPOOL_ID')
+                    return original_set_active_spool(me, int(SPOOL_ID))
+                return original_set_active_spool(me, None)
             return set_active_spool
 
         logging.info('> Allowing SPOOL_ID parameter...')
-
         logging.debug(f'  Before: {SpoolManager.set_active_spool}')
         setattr(SpoolManager, 'set_active_spool', wrap_set_active_spool(SpoolManager.set_active_spool))
         logging.debug(f'  After: {SpoolManager.set_active_spool}')


### PR DESCRIPTION
## Summary

On recent Anycubic firmware updates (observed on Kobra 3), the legacy `M555`
macro path appears to no longer forward its `S=` parameter correctly.
In practice, `M555` consistently resolves to a `None` spool id on the
Moonraker/Spoolman side, regardless of the value passed via `S=`.

With the included `patch_spoolman()` change, direct usage of `SET_SPOOL`
now works reliably. After applying the patch, both parameter spellings
are accepted:

- `SET_SPOOL spool_id=<n>`
- `SET_SPOOL SPOOL_ID=<n>`

Before this patch, `SET_SPOOL` could not be used reliably on its own and
was effectively only usable indirectly via `M555`.

This PR serves both as a fix and as documentation of the changed behavior
observed after newer Anycubic firmware updates.

## Observed behavior

- `M555 S=10`
  → remote call resolves to `spool_id = None`, independent of the provided value

- `SET_SPOOL spool_id=10` (with patch applied)
  → active spool is set correctly

- `SET_SPOOL SPOOL_ID=10` (with patch applied)
  → active spool is set correctly

## Context

`M555` relies on macro parameter forwarding (`params.S`) before calling
`SET_SPOOL`. After the firmware update, this indirection no longer appears
to preserve the parameter value, resulting in `None` being passed through.

The patch updates the SpoolManager handling so that `SET_SPOOL` can be
used directly and consistently, without depending on `M555`.

## Notes

- The issue was reproducible after a recent Anycubic firmware update.
- The patch restores reliable spool selection by accepting both
  `spool_id` and `SPOOL_ID` parameters.
- Both the patch and this PR text were created with the assistance of
  ChatGPT.