### PR TITLE
Improve printers documentations and add Kobra X

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ Current maintainers:
 Special thanks to those people for providing the base research and helping support for more printers:
 - **utkabobr** (https://github.com/utkabobr/DuckPro-Kobra3)
 - **systemik** (https://github.com/systemik/Kobra3-Firmware)
-- **moosbewohner** for Kobra 2 Pro support (https://github.com/moosbewohner/Rinkhals)
-- **Kalenell** and **woswai1337** for Kobra S1 support
-- **evil_santa**, **CalmFrog**, **basvd**, **_René**, **RadioRadio** and more for Kobra 3 Max support
-- Anycubic for the cool printer and the few OSS items (https://github.com/ANYCUBIC-3D/Kobra)
+- **moosbewohner** for Kobra 2 Pro support. (https://github.com/moosbewohner/Rinkhals)
+- **Kalenell** and **woswai1337** for Kobra S1 support.
+- **evil_santa**, **CalmFrog**, **basvd**, **_René**, **RadioRadio** and more for Kobra 3 Max support.
+- **AndrewS** for ethernet adapters USB testing and Kobra X firmware dump.
+- **Ac_K** for passwords and technical discovery of Kobra X.
+- Anycubic for the cool printer and the few OSS items. (https://github.com/ANYCUBIC-3D/Kobra)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -9,16 +9,26 @@ hide:
 
 Welcome to the Rinkhals project documentation!
 
-Rinkhals is a custom firmware overlay for the Anycubic Kobra series of 3D printers. It supports Kobra 3, Kobra 3 Max, Kobra S1 and some Kobra 2 Pro 3D printers.
-This documentation covers what we know about those printers, what we know about Anycubic software, Rinkhals and some high levels guides to achieve specific things.
+Rinkhals is a custom firmware overlay for the Anycubic Kobra series of 3D printers. It supports Kobra 2 Pro, Kobra 3 series, and Kobra S1 series.
+This documentation covers what we know about those printers, the Anycubic software stack, Rinkhals internals, and high-level guides to achieve specific goals.
 
-## Kobra X status
+## Support Status
 
-Some Kobra X firmware packages are publicly available and the SWU password has been recovered.
+### Supported Models (GoKlipper / K3)
+These printers are currently compatible with Rinkhals:
+- **K2P**: [Anycubic Kobra 2 Pro](printers/kobra-2-pro.md)
+- **K3**: [Anycubic Kobra 3](printers/kobra-3.md) (+ Combo)
+- **K3V2**: [Anycubic Kobra 3 V2](printers/kobra-3-v2.md) (+ Combo)
+- **K3M**: [Anycubic Kobra 3 Max](printers/kobra-3-max.md) (+ Combo)
+- **KS1**: [Anycubic Kobra S1](printers/kobra-s1.md) (+ Combo)
+- **KS1M**: [Anycubic Kobra S1 Max](printers/kobra-s1-max.md) (+ Combo)
 
-At the same time, Anycubic switched from the K3 software base (GoKlipper) to a K4 software base using a C++ Klipper port. This makes Kobra X support a separate effort, not a direct extension of current Rinkhals ports.
+### Experimental / Incompatible (KlipperC++ / K4)
+- **K4Pro**: [Anycubic Kobra X](printers/kobra-x.md) — Currently **not supported** due to RSA signature verification.
 
-The SWU process also requires a trusted certificate to accept updates. Until that requirement can be bypassed in a reliable way, SWU-based firmware injection like Rinkhals is not currently possible on Kobra X.
+---
+
+## Getting Started
 
 The main project is located on GitHub: [https://github.com/jbatonnet/Rinkhals](https://github.com/jbatonnet/Rinkhals)<br />
 To quickly start using Rinkhals, check the [quick start guide](guides/rinkhals-quick-start.md)
@@ -31,27 +41,18 @@ If you prefer a video, [Kanrog](https://www.youtube.com/@kanrogcreations) on Dis
     <iframe width="480" height="270" src="https://www.youtube.com/embed/1VpJGZLuQyI?si=lekaw1rFgSfZ6vvT" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </p>
 
-In this documentation, the following printers will be refered to with their model code used everywhere in Rinkhals:
+## Documentation Structure
 
-- K2P: Anycubic Kobra 2 Pro
-- K3: Anycubic Kobra 3 (+ combo)
-- K3V2: Anycubic Kobra 3 V2 (+ combo)
-- K3M: Anycubic Kobra 3 Max (+ combo)
-- KS1: Anycubic Kobra S1 (+ combo)
-- KS1M: Anycubic Kobra S1 Max (+ combo)
-
-## Documentation structure
-
-- [Rinkhals](Rinkhals/index.md): Documentation about Rinkhals, its features and internals
-- [Guides](guides/index.md): High level guides for Simplyprint, Spoolman, ...
-- [Printers](printers/index.md): Generic and specific documentation about the Anycubic Kobra series of 3D printer
-- [Firmware](firmware/index.md): Reverse engineering and documentation about the firmware for those printers
+- [Rinkhals](Rinkhals/index.md): Documentation about Rinkhals, its features and internals.
+- [Guides](guides/index.md): High level guides for Simplyprint, Spoolman, and more.
+- [Printers](printers/index.md): Generic and specific documentation about the Anycubic Kobra series.
+- [Firmware](firmware/index.md): Reverse engineering and documentation about the original firmware.
 
 ## FAQ
 
-Please check the [FAQ](faq.md) for commonly asked questions about Rinkhals
+Please check the [FAQ](faq.md) for commonly asked questions about Rinkhals.
 
-## Useful links
+## Useful Links
 
-- Rinkhals repository on GitHub: [https://github.com/jbatonnet/Rinkhals](https://github.com/jbatonnet/Rinkhals)
-- Rinkhals apps repository on GitHub: [https://github.com/jbatonnet/Rinkhals.apps](https://github.com/jbatonnet/Rinkhals.apps)
+- Rinkhals repository: [https://github.com/jbatonnet/Rinkhals](https://github.com/jbatonnet/Rinkhals)
+- Rinkhals apps repository: [https://github.com/jbatonnet/Rinkhals.apps](https://github.com/jbatonnet/Rinkhals.apps)

--- a/docs/docs/printers/index.md
+++ b/docs/docs/printers/index.md
@@ -3,20 +3,29 @@ title: Kobra printers
 weight: 2
 ---
 
-Overview
+## Overview
+
+This section covers generic and specific documentation about the Anycubic Kobra series.
 
 ## General
 
 - [Mainboard connection](mainboard-connection/index.md)
-- [Recover boot issues](recover-boot-issues.md)
+- [Recover boot issues](recover-boot-issues.md) *(Outdated)*
 
 ## Common specifications
 
-CPU: Rockchip RV1106G3
+- **CPU**: Rockchip RV1106G3
+- **OS**: Linux (Buildroot)
 
 ## Printers
 
+### Supported by Rinkhals (GoKlipper / K3)
 - [Anycubic Kobra 2 Pro](kobra-2-pro.md)
 - [Anycubic Kobra 3](kobra-3.md)
+- [Anycubic Kobra 3 V2](kobra-3-v2.md)
 - [Anycubic Kobra 3 Max](kobra-3-max.md)
 - [Anycubic Kobra S1](kobra-s1.md)
+- [Anycubic Kobra S1 Max](kobra-s1-max.md)
+
+### Not Supported (KlipperC++ / K4)
+- [Anycubic Kobra X](kobra-x.md) (K4Pro)

--- a/docs/docs/printers/kobra-2-pro.md
+++ b/docs/docs/printers/kobra-2-pro.md
@@ -4,10 +4,11 @@ title: Anycubic Kobra 2 Pro
 
 ## General
 
-- SWU password: `U2FsdGVkX19deTfqpXHZnB5GeyQ/dtlbHjkUnwgCi+w=`
-- Ex/Im password: `2YLVrATRvUEnMeXk6Vtc7qxfzYM4TJzrLnEBma8zpUKeGtseGWqp4LXs7e8KeU2u`
-- SSH root password: `rockchip`
-
+- **Software base**: `GoKlipper`
+- **Supported by Rinkhals**: `Yes`
+- **SWU password**: `U2FsdGVkX19deTfqpXHZnB5GeyQ/dtlbHjkUnwgCi+w=`
+- **Ex/Im password**: `2YLVrATRvUEnMeXk6Vtc7qxfzYM4TJzrLnEBma8zpUKeGtseGWqp4LXs7e8KeU2u`
+- **SSH root password**: `rockchip`
 
 ## Firmware history
 

--- a/docs/docs/printers/kobra-3-max.md
+++ b/docs/docs/printers/kobra-3-max.md
@@ -4,9 +4,11 @@ title: Anycubic Kobra 3 Max
 
 ## General
 
-- SWU password: `4DKXtEGStWHpPgZm8Xna9qluzAI8VJzpOsEIgd8brTLiXs8fLSu3vRx8o7fMf4h6`
-- Ex/Im password: `3BPHsCFRsVJdOfYl9Wmb8pkyoZH7UIyqMrDFnc9aqSJhWtudJQnx6Qk9m4JQc3g5`
-- SSH root password: *Unkwown*
+- **Software base**: `GoKlipper`
+- **Supported by Rinkhals**: `Yes`
+- **SWU password**: `4DKXtEGStWHpPgZm8Xna9qluzAI8VJzpOsEIgd8brTLiXs8fLSu3vRx8o7fMf4h6`
+- **Ex/Im password**: `3BPHsCFRsVJdOfYl9Wmb8pkyoZH7UIyqMrDFnc9aqSJhWtudJQnx6Qk9m4JQc3g5`
+- **SSH root password**: `Unknown`
 
 ## Components
 
@@ -22,8 +24,7 @@ title: Anycubic Kobra 3 Max
 
     </div>
 
-    Thanks to evil_santa for the pictures
-
+    Thanks to evil_santa for the pictures.
 
 ## Firmware history
 

--- a/docs/docs/printers/kobra-3-v2.md
+++ b/docs/docs/printers/kobra-3-v2.md
@@ -2,13 +2,13 @@
 title: Anycubic Kobra 3 V2
 ---
 
-
 ## General
 
-- SWU password: `U2FsdGVkX19deTfqpXHZnB5GeyQ/dtlbHjkUnwgCi+w=`
-- Ex/Im password: `2YLVrATRvUEnMeXk6Vtc7qxfzYM4TJzrLnEBma8zpUKeGtseGWqp4LXs7e8KeU2u`
-- SSH root password: `rockchip`
-
+- **Software base**: `GoKlipper`
+- **Supported by Rinkhals**: `Yes`
+- **SWU password**: `U2FsdGVkX19deTfqpXHZnB5GeyQ/dtlbHjkUnwgCi+w=`
+- **Ex/Im password**: `2YLVrATRvUEnMeXk6Vtc7qxfzYM4TJzrLnEBma8zpUKeGtseGWqp4LXs7e8KeU2u`
+- **SSH root password**: `rockchip`
 
 ## Firmware history
 

--- a/docs/docs/printers/kobra-3.md
+++ b/docs/docs/printers/kobra-3.md
@@ -2,13 +2,13 @@
 title: Anycubic Kobra 3
 ---
 
-
 ## General
 
-- SWU password: `U2FsdGVkX19deTfqpXHZnB5GeyQ/dtlbHjkUnwgCi+w=`
-- Ex/Im password: `2YLVrATRvUEnMeXk6Vtc7qxfzYM4TJzrLnEBma8zpUKeGtseGWqp4LXs7e8KeU2u`
-- SSH root password: `rockchip`
-
+- **Software base**: `GoKlipper`
+- **Supported by Rinkhals**: `Yes`
+- **SWU password**: `U2FsdGVkX19deTfqpXHZnB5GeyQ/dtlbHjkUnwgCi+w=`
+- **Ex/Im password**: `2YLVrATRvUEnMeXk6Vtc7qxfzYM4TJzrLnEBma8zpUKeGtseGWqp4LXs7e8KeU2u`
+- **SSH root password**: `rockchip`
 
 ## Components
 
@@ -24,7 +24,6 @@ title: Anycubic Kobra 3
     Cropped image of SW2 and surrounding components (late unit with missing SW2)
 
     </div>
-
 
 ## Firmware history
 

--- a/docs/docs/printers/kobra-s1-max.md
+++ b/docs/docs/printers/kobra-s1-max.md
@@ -4,10 +4,11 @@ title: Anycubic Kobra S1 Max
 
 ## General
 
-- SWU password: `U2FsdGVkX1+lG6cHmshPLI/LaQr9cZCjA8HZt6Y8qmbB7riY`
-- Ex/Im password: `2YLVrATRvUEnMeXk6Vtc7qxfzYM4TJzrLnEBma8zpUKeGtseGWqp4LXs7e8KeU2u`
-- SSH root password: `rockchip`
-
+- **Software base**: `GoKlipper`
+- **Supported by Rinkhals**: `Yes`
+- **SWU password**: `U2FsdGVkX1+lG6cHmshPLI/LaQr9cZCjA8HZt6Y8qmbB7riY`
+- **Ex/Im password**: `2YLVrATRvUEnMeXk6Vtc7qxfzYM4TJzrLnEBma8zpUKeGtseGWqp4LXs7e8KeU2u`
+- **SSH root password**: `rockchip`
 
 ## Firmware history
 

--- a/docs/docs/printers/kobra-s1.md
+++ b/docs/docs/printers/kobra-s1.md
@@ -4,10 +4,11 @@ title: Anycubic Kobra S1
 
 ## General
 
-- SWU password: `U2FsdGVkX1+lG6cHmshPLI/LaQr9cZCjA8HZt6Y8qmbB7riY`
-- Ex/Im password: `2YLVrATRvUEnMeXk6Vtc7qxfzYM4TJzrLnEBma8zpUKeGtseGWqp4LXs7e8KeU2u`
-- SSH root password: `rockchip`
-
+- **Software Base**: `GoKlipper`
+- **Supported by Rinkhals**: `Yes`
+- **SWU password**: `U2FsdGVkX1+lG6cHmshPLI/LaQr9cZCjA8HZt6Y8qmbB7riY`
+- **Ex/Im password**: `2YLVrATRvUEnMeXk6Vtc7qxfzYM4TJzrLnEBma8zpUKeGtseGWqp4LXs7e8KeU2u`
+- **SSH root password**: `rockchip`
 
 ## Firmware history
 

--- a/docs/docs/printers/kobra-x.md
+++ b/docs/docs/printers/kobra-x.md
@@ -1,0 +1,43 @@
+---
+title: Anycubic Kobra X (K4Pro)
+---
+
+## General
+
+- **Software base**: `KlipperC++`
+- **Supported by Rinkhals**: `No` (Blocked by RSA Signature)
+- **Firmware SWU password**: `rCRgz7RMqOyAYCaQ7TgkmPPDyo3LIEqtuEhv8ZEASa7rfwP3p2XoyQZA8IYYV8W3`
+- **MCU SWU password**: `U2FsdGVkX19deTfqpXHZnB5GeyQ/dtlbHjkUnwgCi+w=`
+- **Ex/Im password**: `2YLVrATRvUEnMeXk6Vtc7qxfzYM4TJzrLnEBma8zpUKeGtseGWqp4LXs7e8KeU2u`
+- **SSH root password**: `rockchip`
+
+*Thanks to AndrewS for the system dump and Ac_K for passwords and technical discovery.*
+
+## Software Architecture
+
+The Kobra X (K4 software base) represents a complete overhaul compared to the K3 series. It moves away from the Go-based "GoKlipper" stack (K3SysUi, gklib, gkapi) and introduces a C++ implementation of Klipper.
+
+The core system processes are:
+- **avata_main**: The main control logic (C++ Klipper port).
+- **avata_ui**: The user interface.
+- **avata_video**: The cam control logic.
+
+## Firmware Security & RSA Barrier
+
+The Kobra X introduces mandatory **RSA Signature Verification**. The installer validates the update package (setup.tar.gz) against a public key (/etc/ssl/public_key.pem) using OpenSSL.
+
+Because the setup.tar.gz must be signed by Anycubic's private key to generate a valid setup.sig file, custom firmware injection is currently impossible through standard update methods.
+
+## Potential Bypass and Risks
+
+Future custom firmware installation will require a vulnerability to bypass this check, such as:
+
+1. Physical Access: Using Serial to gain root access and manually overwrite the public key.
+2. Software Vulnerabilities: Finding a flaw in the avata_main or avata_ui processes to achieve arbitrary code execution.
+
+### Stability and Update Warnings
+If a bypass is found and a custom firmware is installed, be aware of the following:
+
+- **OTA Updates**: Over-the-air updates will no longer function.
+- **Manual Updates**: Installing an official firmware file will overwrite the custom firmware and could lead to a system mismatch.
+- **Brick Risk**: Mixing official update components with modified system files carries a significant risk of "bricking" the printer, potentially making it unbootable (Recoverable by Serial).

--- a/docs/docs/printers/kobra-x.md
+++ b/docs/docs/printers/kobra-x.md
@@ -11,8 +11,6 @@ title: Anycubic Kobra X (K4Pro)
 - **Ex/Im password**: `2YLVrATRvUEnMeXk6Vtc7qxfzYM4TJzrLnEBma8zpUKeGtseGWqp4LXs7e8KeU2u`
 - **SSH root password**: `rockchip`
 
-*Thanks to AndrewS for the system dump and Ac_K for passwords and technical discovery.*
-
 ## Software Architecture
 
 The Kobra X (K4 software base) represents a complete overhaul compared to the K3 series. It moves away from the Go-based "GoKlipper" stack (K3SysUi, gklib, gkapi) and introduces a C++ implementation of Klipper.

--- a/docs/docs/printers/usb-compatibility.md
+++ b/docs/docs/printers/usb-compatibility.md
@@ -6,8 +6,6 @@ title: USB devices compatibility
 
 Anycubic Kobra printers run a custom Linux Buildroot distribution. Compatibility depends on the drivers compiled into the kernel. 
 
-**Special thanks to AndrewS for the extensive hardware testing.*
-
 ## Ethernet Adapters
 
 Most "Nintendo Switch compatible" adapters work out of the box. Specifically, those based on the **ASIX AX88179/AX88179A** chipset are verified.

--- a/docs/docs/printers/usb-compatibility.md
+++ b/docs/docs/printers/usb-compatibility.md
@@ -2,19 +2,24 @@
 title: USB devices compatibility
 ---
 
+## Overview
+
+Anycubic Kobra printers run a custom Linux Buildroot distribution. Compatibility depends on the drivers compiled into the kernel. 
+
+**Special thanks to AndrewS for the extensive hardware testing.*
+
+## Ethernet Adapters
+
+Most "Nintendo Switch compatible" adapters work out of the box. Specifically, those based on the **ASIX AX88179/AX88179A** chipset are verified.
+
+### Verified Working Models
+
+| Manufacturer | Model / Reference | Link |
+| :--- | :--- | :--- |
+| **Amazon Basics** | USB 3.0 to Gigabit Ethernet | [Amazon](https://a.co/d/hlnewaz) |
+| **TP-Link** | UE306 (Foldable Design) | [Amazon](https://a.co/d/0bOLvcum) |
+| **UGREEN** | 20256 (USB 3.0) | [Amazon](https://a.co/d/03IOsCMa) |
+
 ## Cameras
 
-X
-
-
-## Ethernet
-
-USB to Ethernet adapters using the AX88179 chip have been tested and are compatible with Kobra printers.
-Thanks to AndrewS for all the testing.
-
-For example:
-
-- [Amazon Basics USB 3.0 to 10/100/1000 Gigabit Ethernet Adapter](https://a.co/d/hlnewaz)
-- TPLink UE306 USB Ethernet Adapter
-- Ugreen 20256
-- Many other "Nintendo Switch Compatible" Ethernet adapters
+Status: Currently unknown.


### PR DESCRIPTION
Refactored documentation structure to distinguish between GoKlipper (K3) and KlipperC++ (K4) architectures. Updated all printer pages (K2P, K3, S1, Kobra X) with support status and recovered passwords.