### PR TITLE
mmu_ace: auto-feed filament at print start when ACE has no loaded slot (#464)

### DIFF
--- a/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
@@ -2358,7 +2358,87 @@ class MmuAcePatcher:
 
             logging.debug(f"mmu_ace: patch_print_data: {json.dumps(print_data)}")
 
+            # Auto-feed filament when the ACE has no slot loaded into the toolhead
+            # going into this print. Without this, prints fail to extrude after the
+            # ACE retracts filament between prints (the touchscreen Color Match →
+            # Print flow currently doesn't issue FEED_FILAMENT; this hook fills
+            # that gap). See issue #464.
+            if self.ace.loaded_gate == TOOL_GATE_UNKNOWN and mapping:
+                target_gate = mapping[0]["ams_index"]
+                logging.info(
+                    f"patch_print_data: no filament currently loaded, "
+                    f"scheduling auto-feed for gate {target_gate}"
+                )
+                self.ace_controller.eventloop.create_task(
+                    self._auto_feed_at_print_start(target_gate)
+                )
+
         return print_data
+
+    async def _auto_feed_at_print_start(self, gate: int) -> None:
+        """Auto-feed filament from `gate` shortly after a print starts.
+
+        Workaround for issue #464: the Color Match → Print flow doesn't issue
+        FEED_FILAMENT, so a print after the ACE has retracted filament starts
+        with an empty nozzle and fails to extrude.
+
+        Waits until the extruder has been commanded to a real print temperature
+        (target >= 190 C) and is within 10 C of target. This avoids triggering
+        during the LeviQ3 probing routine, which oscillates target between
+        170 C (extru_temp) and 140 C (extru_end_temp) -- feeding during that
+        window would either be rejected by min_extrude_temp or ooze onto the
+        probing nozzle.
+        """
+        FEED_TARGET_MIN = 190
+        FEED_TEMP_MARGIN = 10
+        FEED_LENGTH = 80
+        FEED_SPEED = 25
+        MAX_WAIT_SECONDS = 600
+        POLL_INTERVAL = 2.0
+
+        start = time.time()
+        while time.time() - start < MAX_WAIT_SECONDS:
+            try:
+                # Bail if loaded externally (e.g. via MMU_LOAD or T-command)
+                if self.ace.loaded_gate != TOOL_GATE_UNKNOWN:
+                    logging.info(
+                        f"auto-feed: gate {self.ace.loaded_gate} loaded externally, "
+                        f"skipping scheduled auto-feed"
+                    )
+                    return
+
+                result = await self.ace_controller.printer.query_objects({
+                    "extruder": ["temperature", "target"]
+                })
+                ext = result.get("extruder", {}) if isinstance(result, dict) else {}
+                temp = float(ext.get("temperature", 0) or 0)
+                target = float(ext.get("target", 0) or 0)
+
+                if target >= FEED_TARGET_MIN and temp >= (target - FEED_TEMP_MARGIN):
+                    ace_id = gate // 4
+                    local_index = gate % 4
+                    gcode = (
+                        f"FEED_FILAMENT ID={ace_id} INDEX={local_index} "
+                        f"LENGTH={FEED_LENGTH} SPEED={FEED_SPEED}"
+                    )
+                    logging.info(f"auto-feed: sending {gcode}")
+                    await self.ace_controller.printer.send_gcode(gcode)
+
+                    # Update internal state to reflect the loaded gate
+                    self.ace.gate = gate
+                    self.ace.tool = gate
+                    self.ace.loaded_gate = gate
+                    return
+
+            except Exception as exc:
+                logging.warning(f"auto-feed: poll error: {exc}")
+
+            await asyncio.sleep(POLL_INTERVAL)
+
+        logging.warning(
+            f"auto-feed: gave up after {MAX_WAIT_SECONDS}s "
+            f"(extruder target never reached {FEED_TARGET_MIN} C)"
+        )
 
     def _combine(self, sourceA, sourceB):
         result = {}

--- a/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
@@ -2363,11 +2363,23 @@ class MmuAcePatcher:
             # ACE retracts filament between prints (the touchscreen Color Match →
             # Print flow currently doesn't issue FEED_FILAMENT; this hook fills
             # that gap). See issue #464.
+            #
+            # Slot selection order:
+            #   1. self.ace.gate if set — honours touchscreen Color Match selection
+            #      (relies on #443 being fixed; safe fallback if not)
+            #   2. mapping[0].ams_index — the first slot mapped from the slicer's
+            #      tool order. Correct for single-colour prints and for the initial
+            #      feed of multi-colour prints (subsequent T-commands switch).
             if self.ace.loaded_gate == TOOL_GATE_UNKNOWN and mapping:
-                target_gate = mapping[0]["ams_index"]
+                if self.ace.gate != TOOL_GATE_UNKNOWN:
+                    target_gate = self.ace.gate
+                    source = "Color Match (self.ace.gate)"
+                else:
+                    target_gate = mapping[0]["ams_index"]
+                    source = "ams_box_mapping[0]"
                 logging.info(
                     f"patch_print_data: no filament currently loaded, "
-                    f"scheduling auto-feed for gate {target_gate}"
+                    f"scheduling auto-feed for gate {target_gate} (via {source})"
                 )
                 self.ace_controller.eventloop.create_task(
                     self._auto_feed_at_print_start(target_gate)

--- a/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
+++ b/files/4-apps/home/rinkhals/apps/40-moonraker/mmu_ace.py
@@ -541,6 +541,10 @@ class MmuAceController:
         self.eventloop = self.server.get_event_loop()
         self._last_status_update = 0.0
         self._status_update_task: Optional[asyncio.Task] = None
+        # Tracks the single in-flight _plan_load_ace retry loop. set_ace() can be
+        # re-entered (via reinit()); without tracking, overlapping retry loops
+        # would both poll query_objects for up to ~20s.
+        self._plan_load_task: Optional[asyncio.Task] = None
         self._status_update_delay = 0.2  # 200ms debounce for rapid commands
         self._throttle_delay = 0.3  # 300ms minimum delay between updates (max 3/sec)
         self._pending_update = False  # Flag to track if update is needed
@@ -770,7 +774,12 @@ class MmuAceController:
         self.ace = ace
         self._handle_status_update(force=True)
 
-        self.eventloop.create_task(self._plan_load_ace())
+        # Cancel a retry loop left over from an earlier set_ace()/reinit() call
+        # so only one _plan_load_ace can poll at a time.
+        if self._plan_load_task is not None and not self._plan_load_task.done():
+            logging.info("set_ace: cancelling stale _plan_load_ace task")
+            self._plan_load_task.cancel()
+        self._plan_load_task = self.eventloop.create_task(self._plan_load_ace())
 
     async def _plan_load_ace(self, retry=10, delay=2):
         for _ in range(retry):
@@ -1457,6 +1466,11 @@ class MmuAcePatcher:
         self.kobra.register_status_patcher(self.patch_status)
 
         self.kobra.register_print_data_patcher(self.patch_print_data)
+
+        # Tracks the single in-flight auto-feed poller (issue #464). patch_print_data
+        # runs inside kobra.py's network retry loop, so without tracking, a retried
+        # print start would spawn duplicate pollers that all fire FEED_FILAMENT.
+        self._auto_feed_task = None
 
         # Add AnycubicSlicerNext to supported slicers
         self.setup_anycubic_slicer()
@@ -2381,7 +2395,13 @@ class MmuAcePatcher:
                     f"patch_print_data: no filament currently loaded, "
                     f"scheduling auto-feed for gate {target_gate} (via {source})"
                 )
-                self.ace_controller.eventloop.create_task(
+                # Cancel a poller left over from an earlier print-start attempt
+                # (patch_print_data is re-entered on each kobra.py network retry)
+                # so only one auto-feed can ever fire for this print.
+                if self._auto_feed_task is not None and not self._auto_feed_task.done():
+                    logging.info("patch_print_data: cancelling stale auto-feed task")
+                    self._auto_feed_task.cancel()
+                self._auto_feed_task = self.ace_controller.eventloop.create_task(
                     self._auto_feed_at_print_start(target_gate)
                 )
 


### PR DESCRIPTION
## Summary

Fixes #464.

When a print starts on a Rinkhals-equipped Kobra 3 Combo (and likely
other ACE-equipped models) and the ACE has previously retracted filament
back to the hub, the print starts with an empty nozzle. The touchscreen
Color Match → Print flow registers the slot the user picks (`ams.gate`
gets set in some paths), and `patch_print_data` correctly builds an
`ams_box_mapping`, but no `FEED_FILAMENT` is issued anywhere in the
print-start chain. Same behaviour from Fluidd's reprint, Mainsail,
USB-loaded files, and Orca remote-send.

Anycubic Slicer Next prints succeed because its gcode embeds explicit
`T0`/`T1`/`T2`/`T3` tool-change commands that fire GoKlipper's
tool-change handler. Single-colour Orca slices don't have those.

## Approach

Single change at the end of `patch_print_data`:

- If `self.ace.loaded_gate == TOOL_GATE_UNKNOWN` (system reports no
  loaded filament) **and** we just built a non-empty `mapping`, schedule
  an async task to feed the first mapped slot.
- The async helper (`_auto_feed_at_print_start`) waits until the
  extruder has been commanded to a real print temperature
  (`target >= 190°C`, temp within 10°C of target) before issuing
  `FEED_FILAMENT`. This avoids:
  - Triggering during the LeviQ3 probing routine (oscillates between
    170°C `extru_temp` and 140°C `extru_end_temp`) — feeding during
    probing would either be rejected by `min_extrude_temp` or ooze onto
    the probing nozzle.
  - Pre-empting an explicit `T`-command load that the gcode itself
    issues (the helper bails early if `loaded_gate` becomes set).
- On success, updates `self.ace.gate / .tool / .loaded_gate` so
  downstream MMU state is consistent.
- Times out after 600s if target never reaches 190°C — a safety bound
  rather than an expected path.

## Testing

I don't have a Rinkhals development environment, so this PR has only
been smoke-tested as a separate external daemon doing equivalent logic
via Moonraker's HTTP API, on:

- Kobra 3 Combo (with ACE Pro)
- Rinkhals 20260501_01
- Stock 2.4.6.7
- OrcaSlicer 2.3.2

The external daemon's full repo + logic is at:
https://github.com/sharpmonk/ace-autofeed-rinkhals

(Several successful prints validated end-to-end. Daemon log shows the
exact same condition checks + FEED_FILAMENT issue this PR's helper
performs.)

I'd appreciate review from anyone with a multi-unit ACE setup
(`gate / 4` math) or a paint-by-feature multi-colour workflow, since the
in-tree helper takes `mapping[0]["ams_index"]` and a multi-colour print's
mapping has more entries. The intent is: feed the first slot we'll need;
subsequent `T1`/`T2` tool changes in the gcode trigger the existing
tool-change handler.

## Caveats

- Doesn't honour `extruder.target == 0` (e.g. start-gcode that never
  heats the hotend, common for filament-change macros). For those, the
  helper just times out at 600s — no harm, no print started without
  heat anyway.
- The first slot of `mapping` is whatever `patch_print_data` puts first,
  which is currently the first tool with `gate.status >= 1`. If users
  have a workflow where the first **print** colour isn't the lowest gate
  index, this could feed the wrong slot. Open to a smarter selection
  rule if reviewers have one in mind.
- I considered hooking the print-state transition via
  `_handle_mmu_ace_status_update` instead of `patch_print_data` —
  that's likely cleaner, but I went with `patch_print_data` because it
  already runs at the right moment and has the slot mapping in hand.
  Happy to refactor if preferred.

## Test plan

- [ ] Manual: load a non-empty ACE slot, start a single-colour print
      from the touchscreen (Color Match → pick slot → Print), confirm
      FEED_FILAMENT fires and the print extrudes.
- [ ] Manual: same as above but from Fluidd / USB / Orca.
- [ ] Manual: multi-colour print — confirm the in-gcode T1/T2 tool
      changes still work (we feed slot 0, subsequent tool changes are
      not our problem).
- [ ] Manual: filament already loaded when print starts — confirm
      auto-feed bails early (no double-feed).